### PR TITLE
NOZ-49: Decode AND

### DIFF
--- a/riscv/src/instruction.rs
+++ b/riscv/src/instruction.rs
@@ -36,6 +36,12 @@ pub enum RiscVInstruction {
     /// Each bit in the result is 1 if either corresponding bit in the operands is 1.
     Or { rd: u8, rs1: u8, rs2: u8 },
 
+    /// AND instruction (RV32I base instruction set)
+    ///
+    /// Performs bitwise AND between registers `rs1` and `rs2` and stores the result in `rd`.
+    /// Each bit in the result is 1 if both corresponding bits in the operands are 1.
+    And { rd: u8, rs1: u8, rs2: u8 },
+
     /// Add Immediate instruction (RV32I base instruction set)
     ///
     /// Adds the immediate value to register `rs1` and stores the result in `rd`.
@@ -159,6 +165,9 @@ impl fmt::Display for RiscVInstruction {
             RiscVInstruction::Or { rd, rs1, rs2 } => {
                 write!(f, "or x{}, x{}, x{}", rd, rs1, rs2)
             }
+            RiscVInstruction::And { rd, rs1, rs2 } => {
+                write!(f, "and x{}, x{}, x{}", rd, rs1, rs2)
+            }
             RiscVInstruction::Addi { rd, rs1, imm } => {
                 write!(f, "addi x{}, x{}, {}", rd, rs1, imm)
             }
@@ -225,6 +234,8 @@ const XOR_FUNCT3: u8 = 0x4;
 const XOR_FUNCT7: u32 = 0x00;
 const OR_FUNCT3: u8 = 0x6;
 const OR_FUNCT7: u32 = 0x00;
+const AND_FUNCT3: u8 = 0x7;
+const AND_FUNCT7: u32 = 0x00;
 
 const IMM_OPCODE: u32 = 0x13;
 const ADDI_FUNCT3: u8 = 0x0;
@@ -306,6 +317,13 @@ impl RiscVInstruction {
                     OR_FUNCT3 => {
                         if funct7 == OR_FUNCT7 {
                             RiscVInstruction::Or { rd, rs1, rs2 }
+                        } else {
+                            RiscVInstruction::Unsupported(word)
+                        }
+                    }
+                    AND_FUNCT3 => {
+                        if funct7 == AND_FUNCT7 {
+                            RiscVInstruction::And { rd, rs1, rs2 }
                         } else {
                             RiscVInstruction::Unsupported(word)
                         }

--- a/riscv/src/tests/instruction/decode/arithmetic/and.rs
+++ b/riscv/src/tests/instruction/decode/arithmetic/and.rs
@@ -1,0 +1,135 @@
+use crate::instruction::RiscVInstruction;
+
+#[test]
+fn basic() {
+    let and_x1_x2_x3 = 0x003170b3;
+    let decoded = RiscVInstruction::decode(and_x1_x2_x3);
+
+    match decoded {
+        RiscVInstruction::And { rd, rs1, rs2 } => {
+            assert_eq!(rd, 1);
+            assert_eq!(rs1, 2);
+            assert_eq!(rs2, 3);
+        }
+        _ => panic!("Expected AND instruction"),
+    }
+}
+
+#[test]
+fn min_rd() {
+    let and_x0_x1_x2 = 0x0020f033;
+    let decoded = RiscVInstruction::decode(and_x0_x1_x2);
+
+    match decoded {
+        RiscVInstruction::And { rd, rs1, rs2 } => {
+            assert_eq!(rd, 0);
+            assert_eq!(rs1, 1);
+            assert_eq!(rs2, 2);
+        }
+        _ => panic!("Expected AND instruction"),
+    }
+}
+
+#[test]
+fn max_rd() {
+    let and_x31_x1_x2 = 0x0020f033 | (31 << 7);
+    let decoded = RiscVInstruction::decode(and_x31_x1_x2);
+
+    match decoded {
+        RiscVInstruction::And { rd, rs1, rs2 } => {
+            assert_eq!(rd, 31);
+            assert_eq!(rs1, 1);
+            assert_eq!(rs2, 2);
+        }
+        _ => panic!("Expected AND instruction"),
+    }
+}
+
+#[test]
+fn min_rs1() {
+    let and_x1_x0_x2 = 0x00207033 | (1 << 7);
+    let decoded = RiscVInstruction::decode(and_x1_x0_x2);
+
+    match decoded {
+        RiscVInstruction::And { rd, rs1, rs2 } => {
+            assert_eq!(rd, 1);
+            assert_eq!(rs1, 0);
+            assert_eq!(rs2, 2);
+        }
+        _ => panic!("Expected AND instruction"),
+    }
+}
+
+#[test]
+fn max_rs1() {
+    let and_x1_x31_x2 = 0x002ff033 | (1 << 7);
+    let decoded = RiscVInstruction::decode(and_x1_x31_x2);
+
+    match decoded {
+        RiscVInstruction::And { rd, rs1, rs2 } => {
+            assert_eq!(rd, 1);
+            assert_eq!(rs1, 31);
+            assert_eq!(rs2, 2);
+        }
+        _ => panic!("Expected AND instruction"),
+    }
+}
+
+#[test]
+fn min_rs2() {
+    let and_x1_x2_x0 = 0x00017033 | (1 << 7);
+    let decoded = RiscVInstruction::decode(and_x1_x2_x0);
+
+    match decoded {
+        RiscVInstruction::And { rd, rs1, rs2 } => {
+            assert_eq!(rd, 1);
+            assert_eq!(rs1, 2);
+            assert_eq!(rs2, 0);
+        }
+        _ => panic!("Expected AND instruction"),
+    }
+}
+
+#[test]
+fn max_rs2() {
+    let and_x1_x2_x31 = 0x01f17033 | (1 << 7);
+    let decoded = RiscVInstruction::decode(and_x1_x2_x31);
+
+    match decoded {
+        RiscVInstruction::And { rd, rs1, rs2 } => {
+            assert_eq!(rd, 1);
+            assert_eq!(rs1, 2);
+            assert_eq!(rs2, 31);
+        }
+        _ => panic!("Expected AND instruction"),
+    }
+}
+
+#[test]
+fn all_max_values() {
+    let and_x31_x31_x31 = 0x01ffffb3;
+    let decoded = RiscVInstruction::decode(and_x31_x31_x31);
+
+    match decoded {
+        RiscVInstruction::And { rd, rs1, rs2 } => {
+            assert_eq!(rd, 31);
+            assert_eq!(rs1, 31);
+            assert_eq!(rs2, 31);
+        }
+        _ => panic!("Expected AND instruction"),
+    }
+}
+
+#[test]
+fn invalid_funct7_should_be_unsupported() {
+    // AND with invalid funct7 (0x20 instead of 0x00)
+    let invalid_and = 0x203170b3;
+    let decoded = RiscVInstruction::decode(invalid_and);
+
+    match decoded {
+        RiscVInstruction::Unsupported(word) => {
+            assert_eq!(word, 0x203170b3);
+        }
+        _ => panic!("Expected unsupported instruction"),
+    }
+}

--- a/riscv/src/tests/instruction/decode/arithmetic/mod.rs
+++ b/riscv/src/tests/instruction/decode/arithmetic/mod.rs
@@ -1,4 +1,5 @@
 mod add;
+mod and;
 mod or;
 mod sub;
 mod xor;

--- a/riscv/src/tests/instruction/display/arithmetic/and.rs
+++ b/riscv/src/tests/instruction/display/arithmetic/and.rs
@@ -1,0 +1,51 @@
+use crate::instruction::RiscVInstruction;
+
+#[test]
+fn basic() {
+    let and = RiscVInstruction::And {
+        rd: 1,
+        rs1: 2,
+        rs2: 3,
+    };
+    assert_eq!(format!("{}", and), "and x1, x2, x3");
+}
+
+#[test]
+fn min_values() {
+    let and_min = RiscVInstruction::And {
+        rd: 0,
+        rs1: 0,
+        rs2: 0,
+    };
+    assert_eq!(format!("{}", and_min), "and x0, x0, x0");
+}
+
+#[test]
+fn max_values() {
+    let and_max = RiscVInstruction::And {
+        rd: 31,
+        rs1: 31,
+        rs2: 31,
+    };
+    assert_eq!(format!("{}", and_max), "and x31, x31, x31");
+}
+
+#[test]
+fn mixed_registers() {
+    let and_mixed = RiscVInstruction::And {
+        rd: 5,
+        rs1: 10,
+        rs2: 15,
+    };
+    assert_eq!(format!("{}", and_mixed), "and x5, x10, x15");
+}
+
+#[test]
+fn same_registers() {
+    let and_same = RiscVInstruction::And {
+        rd: 7,
+        rs1: 7,
+        rs2: 7,
+    };
+    assert_eq!(format!("{}", and_same), "and x7, x7, x7");
+}

--- a/riscv/src/tests/instruction/display/arithmetic/mod.rs
+++ b/riscv/src/tests/instruction/display/arithmetic/mod.rs
@@ -1,4 +1,5 @@
 mod add;
+mod and;
 mod or;
 mod sub;
 mod xor;


### PR DESCRIPTION
## Summary

Implements AND instruction decoding support for RV32I base instruction set. Adds decoding logic for the AND instruction (funct3=0x7, funct7=0x00) with proper register parameter handling, display formatting, and comprehensive test coverage.

## Changes

- Added `AND` enum variant to instruction set with rd, rs1, rs2 parameters
- Implemented decoding logic for AND instruction opcode pattern  
- Added display formatting as "and x{rd}, x{rs1}, x{rs2}"
- Added comprehensive decode and display tests for AND instruction

Resolves NOZ-49